### PR TITLE
Show the whole product row when embedding an article.

### DIFF
--- a/components/Markdown/Markdown.component.jsx
+++ b/components/Markdown/Markdown.component.jsx
@@ -5,8 +5,7 @@ import styles from './Markdown.module.scss'
 import { getStrapiMedia } from '../../utils/media'
 import rehypeRaw from 'rehype-raw'
 import { fetchAPI } from '../../lib/api'
-
-import ProductCard from '../ProductCard/ProductCard.component'
+import ProductRow from '../ProductTable/ProductRow/ProductRow.component'
 import reactDom from 'react-dom'
 
 const customComponentDataFetcher = {
@@ -18,22 +17,8 @@ const customComponentDataFetcher = {
 
         if (productData) {
           reactDom.render(
-            <div
-              style={{
-                margin: '2rem auto',
-                display: 'flex',
-                justifyContent: 'center'
-              }}
-            >
-              <a href={productData.chLink} target='_blank' rel='noreferrer'>
-                <ProductCard
-                  name={productData?.name}
-                  type={productData?.type}
-                  tradeDuration={productData?.tradeDuration}
-                  tradeFreq={productData?.tradeFreq}
-                  experience={productData?.experience}
-                />
-              </a>
+            <div className={styles.product}>
+              <ProductRow product={productData} />
             </div>,
             element
           )

--- a/components/Markdown/Markdown.module.scss
+++ b/components/Markdown/Markdown.module.scss
@@ -30,6 +30,11 @@
     margin: 20px auto;
   }
 }
+.product {
+  background: hsl(var(--clr-light) / 0.2);
+  border-radius: 8px;
+  margin: '2rem auto';
+}
 .markdownStyling {
   position: relative;
   & img {

--- a/components/ProductTable/ProductRow/ProductRow.component.js
+++ b/components/ProductTable/ProductRow/ProductRow.component.js
@@ -9,19 +9,18 @@ import List from '../../List/List.component'
 import currency from 'currency.js'
 
 export default function ProductRow({ product }) {
-  console.log(product)
   if (!product) return null
 
   return (
     <div className={styles.productRowContainer}>
       <div className={clsx(styles.row, styles.productRow)} key={product.id}>
         <div className={styles.cell}>
-          <Link linkTo={`/product/${product.slug}`}>
+          <a href={`/product/${product.slug}`}>
             <ProductCard
               {...product}
               experience={product?.experience.map((e) => e.experience)}
             />
-          </Link>
+          </a>
           <div className='text-acccent mt-1'>
             {product.price === 0 ? 'Free' : product.price}
           </div>
@@ -50,11 +49,11 @@ export default function ProductRow({ product }) {
 
           <div className={styles.controls}>
             <div className='mt-2'>
-              <Link linkTo={`/product/${product.slug}`}>
+              <a href={`/product/${product.slug}`} type='nav'>
                 <Button type='outlined' fullWidth>
                   More Info
                 </Button>
-              </Link>
+              </a>
             </div>
             <div className='mt-1'>
               <a href={product.chLink} target='_blank' rel='noreferrer'>


### PR DESCRIPTION
### Types of changes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [x]  Enhancement (non-breaking change which cleans up / improves existing functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

### Description

- Adding products to articles now embeds the whole product row instead of just the product card.
- All links work, internal links required the use of "a" tags instead of Next links.



![Capture](https://user-images.githubusercontent.com/84047585/154823236-09710e8a-3d22-4a90-84d3-1ff2f0f47353.PNG)
.